### PR TITLE
Update email form assertions

### DIFF
--- a/blog/tests/forms_test.py
+++ b/blog/tests/forms_test.py
@@ -9,3 +9,7 @@ def test_mail(mailoutbox):
     email_form.send_email()
 
     assert len(mailoutbox) == 1
+    email = mailoutbox[0]
+    assert data["subject"] in email.subject
+    assert data["message"] in email.body
+    assert email.from_email == settings.DEFAULT_FROM_EMAIL


### PR DESCRIPTION
## Summary
- extend email form test to check subject, body and from address

## Testing
- `pytest` *(fails: unrecognized arguments --ds=website.settings.test)*

------
https://chatgpt.com/codex/tasks/task_e_6857f5005c488326ba5ecb2f3c0e046b