### PR TITLE
Fix telegram token ignore comment

### DIFF
--- a/blog/services/telegram.py
+++ b/blog/services/telegram.py
@@ -1,7 +1,7 @@
 import requests
 from django.conf import settings
 
-TELEGRAM_TOKEN = settings.TELEGRAM_TOKEN  # trype: ignore
+TELEGRAM_TOKEN = settings.TELEGRAM_TOKEN  # type: ignore
 TELEGRAM_CHAT_ID = settings.TELEGRAM_CHAT_ID  # type: ignore
 
 BASE_URL = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}"


### PR DESCRIPTION
## Summary
- fix a comment typo in `telegram.py`

## Testing
- `pytest -q` *(fails: unrecognized arguments --ds=website.settings.test)*

------
https://chatgpt.com/codex/tasks/task_e_6857f4e40d588326a9340bc0a6d679b8