### PR TITLE
Fix user factory last name faker

### DIFF
--- a/blog/tests/factories.py
+++ b/blog/tests/factories.py
@@ -10,7 +10,7 @@ class UserFactory(factory.django.DjangoModelFactory):
 
     username = factory.Sequence(lambda n: f"eduzen{n}")
     first_name = factory.Faker("first_name")
-    first_name = factory.Faker("first_name")
+    last_name = factory.Faker("last_name")
     email = factory.LazyAttribute(lambda obj: f"{obj.username}@eduzen.ar")
     password = factory.django.Password("pw")
 


### PR DESCRIPTION
## Summary
- set `UserFactory.last_name` to use the last name faker

## Testing
- `pytest` *(fails: unrecognized arguments --ds=website.settings.test)*

------
https://chatgpt.com/codex/tasks/task_e_6857f4f0ce148326a01715509350585e